### PR TITLE
Allow using isnull to select unassociated records

### DIFF
--- a/test/ecto_query_builder_test.exs
+++ b/test/ecto_query_builder_test.exs
@@ -478,6 +478,22 @@ defmodule EctoQueryBuilderTest do
     assert inspect(expected) == inspect(result)
   end
 
+  test "fiql filter with isnull filter on id of associated record" do
+    {:ok, result} =
+      FIQLEx.build_query(FIQLEx.parse!("domain.id=isnull=false"), EctoQueryBuilder,
+        schema: UserSchema,
+        select: :from_selectors
+      )
+
+    expected =
+      from(u0 in FIQLEx.Test.Support.User,
+        where: is_nil(u0.domain_id) == ^false,
+        order_by: []
+      )
+
+    assert inspect(expected) == inspect(result)
+  end
+
   test "fiql filter with associations comparing dates with gt and lt" do
     {:ok, result} =
       FIQLEx.build_query(


### PR DESCRIPTION
On schema A which has a nullable `belongs_to` association with schema B, named `b`, allow use of `b.id=isnull=true` to retrieve records of A which are not associated with any record of B. This is done by filtering directly on the `b_id` field of A without a subquery.